### PR TITLE
Fix Carousel when scrolling to the end

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@python-italia/pycon-styleguide",
-  "version": "0.1.43",
+  "version": "0.1.44-rc2",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@python-italia/pycon-styleguide",
-  "version": "0.1.44-rc2",
+  "version": "0.1.44-rc3",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@python-italia/pycon-styleguide",
-  "version": "0.1.44-rc3",
+  "version": "0.1.44",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",

--- a/src/carousel/carousel.tsx
+++ b/src/carousel/carousel.tsx
@@ -63,18 +63,19 @@ export const Carousel = ({ title, children }: Props) => {
   const [currentIndex, setCurrentIndex] = useState(0);
 
   const totalCount = React.Children.count(children);
+  const pageSize = window?.innerWidth > 768 ? 4 : 1;
 
   const previous = () => setCurrentIndex(Math.max(0, currentIndex - 1));
   const next = () =>
-    setCurrentIndex(Math.min(totalCount - 1, currentIndex + 1));
+    setCurrentIndex(Math.min(totalCount - pageSize, currentIndex + 1));
 
   return (
     <div>
-      <div className="border-black border-b-4">
-        <div className="max-w-7xl mx-auto px-8 py-8 flex">
+      <div className="border-b-4 border-black">
+        <div className="flex px-8 py-8 mx-auto max-w-7xl">
           <Title marginBottom={false}>{title}</Title>
 
-          <div className="ml-auto flex 2xl:hidden">
+          <div className="flex ml-auto 2xl:hidden">
             <button className="flex h-full py-4" onClick={previous}>
               <LeftArrow className="h-5" />
             </button>
@@ -84,12 +85,12 @@ export const Carousel = ({ title, children }: Props) => {
           </div>
         </div>
       </div>
-      <div className="max-w-7xl mx-auto flex-1 w-full relative">
+      <div className="relative flex-1 w-full mx-auto max-w-7xl">
         <ArrowButton onClick={previous} className="pr-16 -left-28" />
 
-        <div className="w-full overflow-hidden border-black border-l-4">
+        <div className="w-full overflow-hidden border-l-4 border-black">
           <div
-            className="flex transform transition-transform carousel-container"
+            className="flex transition-transform transform carousel-container"
             style={
               {
                 "--current-index": currentIndex,
@@ -99,8 +100,8 @@ export const Carousel = ({ title, children }: Props) => {
           >
             {React.Children.map(children, (child, index) => {
               return (
-                <div className="w-full md:w-1/4 flex-shrink-0">
-                  <div className="aspect-w-1 aspect-h-1 border-r-4 border-black">
+                <div className="flex-shrink-0 w-full md:w-1/4">
+                  <div className="border-r-4 border-black aspect-w-1 aspect-h-1">
                     {React.cloneElement(child as React.ReactElement, {
                       className: `bg-${COLORS[index % COLORS.length]}`,
                     })}

--- a/src/carousel/carousel.tsx
+++ b/src/carousel/carousel.tsx
@@ -8,6 +8,9 @@ type Props = {
   children: React.ReactNode;
 };
 
+const MAX_PAGE_SIZE = 4;
+const MIN_PAGE_SIZE = 1;
+
 const LeftArrow = ({ className }: { className?: string }) => (
   <svg width="46" height="53" viewBox="0 0 46 53" className={className}>
     <path
@@ -61,7 +64,7 @@ const ArrowButton = ({
 
 export const Carousel = ({ title, children }: Props) => {
   const [currentIndex, setCurrentIndex] = useState(0);
-  const [pageSize, setPageSize] = useState(4);
+  const [pageSize, setPageSize] = useState(MAX_PAGE_SIZE);
 
   const totalCount = React.Children.count(children);
 
@@ -71,18 +74,15 @@ export const Carousel = ({ title, children }: Props) => {
 
   useEffect(() => {
     const listener = () => {
-      const maxPageSize = 4;
-      const minPageSize = 1;
-
       if (window.innerWidth >= 768) {
-        const maxIndexForSize = totalCount - maxPageSize;
+        const maxIndexForSize = totalCount - MAX_PAGE_SIZE;
 
-        setPageSize(maxPageSize);
+        setPageSize(MAX_PAGE_SIZE);
         setCurrentIndex((value) =>
           value > maxIndexForSize ? maxIndexForSize : value
         );
       } else {
-        setPageSize(minPageSize);
+        setPageSize(MIN_PAGE_SIZE);
       }
     };
 

--- a/src/carousel/carousel.tsx
+++ b/src/carousel/carousel.tsx
@@ -63,7 +63,7 @@ export const Carousel = ({ title, children }: Props) => {
   const [currentIndex, setCurrentIndex] = useState(0);
 
   const totalCount = React.Children.count(children);
-  const pageSize = window?.innerWidth > 768 ? 4 : 1;
+  const pageSize = window?.innerWidth >= 768 ? 4 : 1;
 
   const previous = () => setCurrentIndex(Math.max(0, currentIndex - 1));
   const next = () =>

--- a/src/carousel/carousel.tsx
+++ b/src/carousel/carousel.tsx
@@ -63,7 +63,8 @@ export const Carousel = ({ title, children }: Props) => {
   const [currentIndex, setCurrentIndex] = useState(0);
 
   const totalCount = React.Children.count(children);
-  const pageSize = window?.innerWidth >= 768 ? 4 : 1;
+  const pageSize =
+    typeof window !== "undefined" && window.innerWidth >= 768 ? 4 : 1;
 
   const previous = () => setCurrentIndex(Math.max(0, currentIndex - 1));
   const next = () =>

--- a/src/carousel/carousel.tsx
+++ b/src/carousel/carousel.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Title } from "../title";
 import { Color } from "../types";
 
@@ -61,14 +61,38 @@ const ArrowButton = ({
 
 export const Carousel = ({ title, children }: Props) => {
   const [currentIndex, setCurrentIndex] = useState(0);
+  const [pageSize, setPageSize] = useState(4);
 
   const totalCount = React.Children.count(children);
-  const pageSize =
-    typeof window !== "undefined" && window.innerWidth >= 768 ? 4 : 1;
 
   const previous = () => setCurrentIndex(Math.max(0, currentIndex - 1));
   const next = () =>
     setCurrentIndex(Math.min(totalCount - pageSize, currentIndex + 1));
+
+  useEffect(() => {
+    const listener = () => {
+      const maxPageSize = 4;
+      const minPageSize = 1;
+
+      if (window.innerWidth >= 768) {
+        const maxIndexForSize = totalCount - maxPageSize;
+
+        setPageSize(maxPageSize);
+        setCurrentIndex((value) =>
+          value > maxIndexForSize ? maxIndexForSize : value
+        );
+      } else {
+        setPageSize(minPageSize);
+      }
+    };
+
+    listener();
+    window.addEventListener("resize", listener);
+
+    return () => {
+      window.removeEventListener("resize", listener);
+    };
+  }, []);
 
   return (
     <div>


### PR DESCRIPTION
Go to https://pycon-styleguide-git-fix-carousel-next-prev-python-italia.vercel.app/iframe.html?id=carousel--standard&args=&viewMode=story

case #1:

Use the next arrow to go to the end
Resize the browser to go mobile
Click the arrow again until the end
Resize back to desktop
Click the back button, it should work

case #2:

On desktop mode, scroll to the end
Click the next arrow a few times
Click the back arrow, it should work right away